### PR TITLE
Removes Typeable requirement from HasParam

### DIFF
--- a/src/Beeline/RouteDocumenter.hs
+++ b/src/Beeline/RouteDocumenter.hs
@@ -33,17 +33,15 @@ documentRoutePiece pieceText subDocumenter =
     let (method, path) = documentRoute subDocumenter a
     in (method, "/" <> pieceText <> path)
 
-documentRouteParam :: (param -> Text)
+documentRouteParam :: Text
                    -> (Text -> Either Text param)
                    -> (param -> Text)
                    -> (route -> param)
                    -> RouteDocumenter (param -> route)
                    -> RouteDocumenter route
-documentRouteParam paramToName _ _ getParam subDocumenter =
+documentRouteParam paramName _ _ _ subDocumenter =
   RouteDocumenter $ \a ->
-    let param = getParam a
-        paramName = paramToName param
-        (method, path) = documentRoute subDocumenter $ const a
+    let (method, path) = documentRoute subDocumenter $ const a
     in (method, "/" <> "{" <> paramName <> "}" <> path)
 
 documentRouteEnd :: HTTP.StdMethod -> a -> RouteDocumenter a

--- a/src/Beeline/RouteGenerator.hs
+++ b/src/Beeline/RouteGenerator.hs
@@ -33,7 +33,7 @@ generateRoutePiece pieceText subGenerator =
     let (method, path) = generateRoute subGenerator a
     in (method, "/" <> pieceText <> path)
 
-generateRouteParam :: (a -> Text)
+generateRouteParam :: Text
                    -> (Text -> Either Text param)
                    -> (param -> Text)
                    -> (route -> param)

--- a/src/Beeline/RouteRecognizer.hs
+++ b/src/Beeline/RouteRecognizer.hs
@@ -42,7 +42,7 @@ recognizeRoutePiece expectedPiece subRouter =
         then recognizeRoute subRouter method ps
         else Left "No route matched"
 
-recognizeRouteParam :: (a -> Text)
+recognizeRouteParam :: Text
                     -> (Text -> Either Text param)
                     -> (param -> Text)
                     -> (route -> param)

--- a/src/Beeline/Router.hs
+++ b/src/Beeline/Router.hs
@@ -15,36 +15,37 @@ module Beeline.Router
   , emptyRoutes
   ) where
 
-import qualified Data.Text as T
 import           Data.Text (Text)
 import           Data.Kind (Type)
-import           Data.Typeable (typeOf, showsTypeRep, Typeable)
 import           Shrubbery (Union)
 import           Shrubbery.TypeList (KnownLength)
 
 import qualified Network.HTTP.Types as HTTP
 
-class Typeable a => HasParam a where
-  name :: a -> Text -- for documentation
-  name a = T.pack $ (showsTypeRep $ typeOf a) ""
+class HasParam a where
+  name :: proxy a -> Text -- for documentation
+  parseParam :: Text -> Either Text a
+  renderParam   :: a -> Text
 
-  fromText :: Text -> Either Text a
-  toText   :: a -> Text
+param :: (HasParam a, Router r) => (b -> a) -> r (a -> b) -> r b
+param accessor =
+  explicitParam
+    (name accessor) -- uses the accessor as a `proxy a` to get the name of the param
+    parseParam
+    renderParam
+    accessor
 
 class Router r where
   data RouteList r (subRoutes :: [Type]) :: *
 
   piece         :: Text -> r a -> r a
-  explicitParam ::
-                   (a -> Text) -- the "name" of the parameter for documentation
+  explicitParam ::  -- |  the name of the parameter for documentation
+                   Text
                 -> (Text -> Either Text a)
                 -> (a -> Text)
                 -> (b -> a)
                 -> r (a -> b)
                 -> r b
-
-  param :: HasParam a => (b -> a) -> r (a -> b) -> r b
-  param = explicitParam name fromText toText
 
   end         :: HTTP.StdMethod -> a -> r a
   routeList   :: KnownLength types => RouteList r types -> r (Union types)


### PR DESCRIPTION
This removes the `Typeable` superclass constraint from `HasParam` in
favor of having the user implement the `name` method of `HasParam`
directly.