### PR TITLE
Adds ParameterDefinition, replacing HasParam

### DIFF
--- a/beeline.cabal
+++ b/beeline.cabal
@@ -21,6 +21,7 @@ source-repository head
 library
   exposed-modules:
       Beeline
+      Beeline.ParameterDefinition
       Beeline.RouteDocumenter
       Beeline.RouteGenerator
       Beeline.Router
@@ -31,7 +32,8 @@ library
       src
   ghc-options: -Wall -Wno-name-shadowing
   build-depends:
-      base
+      attoparsec
+    , base
     , http-types
     , shrubbery
     , text
@@ -51,7 +53,8 @@ test-suite spec
       test
   ghc-options: -Wall -Wno-name-shadowing -j -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Woverflowed-literals
   build-depends:
-      base
+      attoparsec
+    , base
     , beeline
     , hedgehog
     , http-types

--- a/package.yaml
+++ b/package.yaml
@@ -12,6 +12,7 @@ library:
   source-dirs: src
   exposed-modules:
     - Beeline
+    - Beeline.ParameterDefinition
     - Beeline.RouteDocumenter
     - Beeline.RouteGenerator
     - Beeline.Router
@@ -22,6 +23,7 @@ dependencies:
   - http-types
   - shrubbery
   - text
+  - attoparsec
 
 ghc-options:
   - -Wall

--- a/src/Beeline.hs
+++ b/src/Beeline.hs
@@ -2,6 +2,7 @@ module Beeline
   ( module Export
   ) where
 
+import Beeline.ParameterDefinition as Export
 import Beeline.RouteDocumenter as Export
 import Beeline.RouteGenerator as Export
 import Beeline.Router as Export

--- a/src/Beeline/ParameterDefinition.hs
+++ b/src/Beeline/ParameterDefinition.hs
@@ -1,0 +1,70 @@
+module Beeline.ParameterDefinition
+  ( ParameterDefinition(..)
+  , textParam
+  , integralParam
+  , coerceParam
+  , convertParam
+  , parsedParam
+  ) where
+
+import           Control.Monad ((<=<))
+import qualified Data.Attoparsec.Text as Atto
+import qualified Data.Bifunctor as Bifunctor
+import           Data.Coerce (Coercible, coerce)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LTB
+import qualified Data.Text.Lazy.Builder.Int as LTBI
+
+data ParameterDefinition param =
+  ParameterDefinition
+    { parameterName :: Text
+    , parameterParser :: Text -> Either Text param
+    , parameterRenderer :: param -> Text
+    }
+
+textParam :: Text -> ParameterDefinition Text
+textParam name =
+  ParameterDefinition
+    { parameterName = name
+    , parameterParser = Right
+    , parameterRenderer = id
+    }
+
+coerceParam :: Coercible a b => ParameterDefinition b -> ParameterDefinition a
+coerceParam =
+  convertParam (Right . coerce) coerce
+
+parsedParam :: Text
+            -> Atto.Parser param
+            -> (param -> Text)
+            -> ParameterDefinition param
+parsedParam name attoParser renderer =
+  let
+    parser =
+      Bifunctor.first T.pack
+      . Atto.parseOnly (attoParser <* Atto.endOfInput)
+  in
+    ParameterDefinition
+      { parameterName = name
+      , parameterParser = parser
+      , parameterRenderer = renderer
+      }
+
+integralParam :: Integral n => Text -> ParameterDefinition n
+integralParam name =
+  parsedParam
+    name
+    (Atto.signed Atto.decimal)
+    (LT.toStrict . LTB.toLazyText . LTBI.decimal)
+
+convertParam :: (a -> Either Text b)
+             -> (b -> a)
+             -> ParameterDefinition a
+             -> ParameterDefinition b
+convertParam parse render paramDef =
+  paramDef
+    { parameterParser = parse <=< parameterParser paramDef
+    , parameterRenderer = parameterRenderer paramDef . render
+    }

--- a/src/Beeline/Router.hs
+++ b/src/Beeline/Router.hs
@@ -5,9 +5,7 @@
 module Beeline.Router
   ( Router
   , RouteList
-  , HasParam(..)
   , piece
-  , explicitParam
   , param
   , end
   , routeList
@@ -20,32 +18,17 @@ import           Data.Kind (Type)
 import           Shrubbery (Union)
 import           Shrubbery.TypeList (KnownLength)
 
+import           Beeline.ParameterDefinition (ParameterDefinition)
 import qualified Network.HTTP.Types as HTTP
-
-class HasParam a where
-  name :: proxy a -> Text -- for documentation
-  parseParam :: Text -> Either Text a
-  renderParam   :: a -> Text
-
-param :: (HasParam a, Router r) => (b -> a) -> r (a -> b) -> r b
-param accessor =
-  explicitParam
-    (name accessor) -- uses the accessor as a `proxy a` to get the name of the param
-    parseParam
-    renderParam
-    accessor
 
 class Router r where
   data RouteList r (subRoutes :: [Type]) :: *
 
-  piece         :: Text -> r a -> r a
-  explicitParam ::  -- |  the name of the parameter for documentation
-                   Text
-                -> (Text -> Either Text a)
-                -> (a -> Text)
-                -> (b -> a)
-                -> r (a -> b)
-                -> r b
+  piece :: Text -> r a -> r a
+  param :: ParameterDefinition a
+        -> (b -> a)
+        -> r (a -> b)
+        -> r b
 
   end         :: HTTP.StdMethod -> a -> r a
   routeList   :: KnownLength types => RouteList r types -> r (Union types)

--- a/test/Fixtures/TextParam.hs
+++ b/test/Fixtures/TextParam.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Fixtures.TextParam
   ( TextParam
+  , textParamDef
   , genTextParam
   ) where
 
@@ -15,10 +16,9 @@ newtype TextParam =
   TextParam Text
   deriving (Eq, Show)
 
-instance Beeline.HasParam TextParam where
-  name _ = "TextParam"
-  parseParam = Right . TextParam
-  renderParam (TextParam txt) = txt
+textParamDef :: Beeline.ParameterDefinition TextParam
+textParamDef =
+  Beeline.coerceParam (Beeline.textParam "TextParam")
 
 genTextParam :: HH.Gen TextParam
 genTextParam =

--- a/test/Test/RouteGenerator.hs
+++ b/test/Test/RouteGenerator.hs
@@ -15,7 +15,7 @@ import qualified Network.HTTP.Types as HTTP
 import qualified Beeline as Beeline
 import qualified Fixtures.FooBarBaz as FBB
 import           Fixtures.SimpleNoArgRoute (SimpleNoArgRoute(SimpleNoArgRoute))
-import           Fixtures.TextParam (genTextParam)
+import           Fixtures.TextParam (textParamDef, genTextParam)
 
 tests :: IO Bool
 tests =
@@ -57,12 +57,12 @@ prop_param =
 
     let
       generator =
-        Beeline.param id $ Beeline.end method id
+        Beeline.param textParamDef id $ Beeline.end method id
 
       result =
         Beeline.generateRoute generator param
 
-    result === (method, "/" <> Beeline.renderParam param)
+    result === (method, "/" <> Beeline.parameterRenderer textParamDef param)
 
 prop_routeList :: HH.Property
 prop_routeList =

--- a/test/Test/RouteRecognizer.hs
+++ b/test/Test/RouteRecognizer.hs
@@ -14,7 +14,7 @@ import qualified Network.HTTP.Types as HTTP
 import qualified Beeline as Beeline
 import qualified Fixtures.FooBarBaz as FBB
 import           Fixtures.SimpleNoArgRoute (SimpleNoArgRoute(SimpleNoArgRoute))
-import           Fixtures.TextParam (genTextParam)
+import           Fixtures.TextParam (textParamDef, genTextParam)
 
 tests :: IO Bool
 tests =
@@ -51,10 +51,10 @@ prop_param =
 
     let
       recognizer =
-        Beeline.param id $ Beeline.end method id
+        Beeline.param textParamDef id $ Beeline.end method id
 
       result =
-        Beeline.recognizeRoute recognizer method [Beeline.renderParam param]
+        Beeline.recognizeRoute recognizer method [Beeline.parameterRenderer textParamDef param]
 
     result === Right param
 


### PR DESCRIPTION
This replaces the `HasParam` typeclass with a `ParameterDefinition`
record that captures the name, parsing and rendering functions for the
parameter.