### PR TITLE
Adds support for multiple path parameters

### DIFF
--- a/src/Beeline/RouteGenerator.hs
+++ b/src/Beeline/RouteGenerator.hs
@@ -3,48 +3,83 @@
 
 module Beeline.RouteGenerator
   ( RouteGenerator(..)
+  , generateRoute
   ) where
 
 import qualified Network.HTTP.Types as HTTP
 import           Shrubbery (BranchBuilder, dissect, branch, branchBuild, branchEnd)
 import           Data.Text (Text)
+import qualified Data.Text as T
 
 import           Beeline.Router (Router(..))
 import           Beeline.ParameterDefinition (ParameterDefinition(parameterRenderer))
 
-newtype RouteGenerator a =
+newtype RouteGenerator route =
   RouteGenerator
-    { generateRoute :: a -> (HTTP.StdMethod, Text)
+    { generateSubroute :: route -> ([Text] -> [Text]) -> (HTTP.StdMethod, Text)
     }
+
+generateRoute :: RouteGenerator route -> route -> (HTTP.StdMethod, Text)
+generateRoute generator route =
+  generateSubroute generator route id
 
 instance Router RouteGenerator where
   newtype RouteList RouteGenerator subRoutes =
-    RouteBranches (BranchBuilder subRoutes (HTTP.StdMethod, Text))
+    RouteBranches (BranchBuilder subRoutes (([Text] -> [Text]) -> (HTTP.StdMethod, Text)))
 
-  piece         = generateRoutePiece
-  param         = generateRouteParam
-  end           = generateRouteEnd
+  newtype RoutePieces RouteGenerator route a =
+    RoutePieces (route -> ([Text] -> [Text]) -> (HTTP.StdMethod, Text))
+
+  route = generateRouteRoute
+  piece = generateRoutePiece
+  param = generateRouteParam
+  end = generateRoutePiecesEnd
+  subrouter = generateRoutePiecesSubRouter
   routeList (RouteBranches branches) = RouteGenerator (dissect (branchBuild branches))
   addRoute (RouteGenerator route) (RouteBranches branches) = RouteBranches $ branch route branches
   emptyRoutes = RouteBranches branchEnd
 
-generateRoutePiece :: Text -> RouteGenerator a -> RouteGenerator a
-generateRoutePiece pieceText subGenerator =
-  RouteGenerator $ \a ->
-    let (method, path) = generateRoute subGenerator a
-    in (method, "/" <> pieceText <> path)
-
-generateRouteParam :: ParameterDefinition param
-                   -> (route -> param)
-                   -> RouteGenerator (param -> route)
+generateRouteRoute :: a
+                   -> RoutePieces RouteGenerator route (a -> route)
                    -> RouteGenerator route
-generateRouteParam paramDef getParam subGenerator =
-  RouteGenerator $ \a ->
-    let param = getParam a
-        paramText = parameterRenderer paramDef param
-        (method, path) = generateRoute subGenerator $ const a
-    in (method, "/" <> paramText <> path)
+generateRouteRoute _ (RoutePieces f) =
+  RouteGenerator f
 
-generateRouteEnd :: HTTP.StdMethod -> a -> RouteGenerator a
-generateRouteEnd method _ =
-  RouteGenerator $ const (method, "")
+generateRoutePiece :: Text
+                   -> RoutePieces RouteGenerator route a
+                   -> RoutePieces RouteGenerator route a
+generateRoutePiece pieceText (RoutePieces generateRest) =
+  RoutePieces $ \route mkPath ->
+    generateRest route (mkPath . (pieceText:))
+
+generateRouteParam :: ParameterDefinition a
+                   -> (route -> a)
+                   -> RoutePieces RouteGenerator route (c -> route)
+                   -> RoutePieces RouteGenerator route ((a -> c) -> route)
+generateRouteParam paramDef accessor (RoutePieces generateRest) =
+  RoutePieces $ \route mkPath ->
+    let
+      param =
+        accessor route
+
+      paramText =
+        parameterRenderer paramDef param
+    in
+      generateRest route (mkPath . (paramText:))
+
+generateRoutePiecesEnd :: HTTP.StdMethod -> RoutePieces RouteGenerator route (route -> route)
+generateRoutePiecesEnd method =
+  RoutePieces $ \_ mkPath ->
+    let
+      pathParts =
+        mkPath []
+    in
+      (method, "/" <> T.intercalate "/" pathParts)
+
+generateRoutePiecesSubRouter :: (route -> subroute)
+                             -> RouteGenerator subroute
+                             -> RoutePieces RouteGenerator route ((subroute -> route) -> route)
+generateRoutePiecesSubRouter accessor subrouter =
+  RoutePieces $ \route mkPath ->
+    generateSubroute subrouter (accessor route) mkPath
+

--- a/test/Fixtures/FooBarBaz.hs
+++ b/test/Fixtures/FooBarBaz.hs
@@ -4,6 +4,7 @@ module Fixtures.FooBarBaz
   ( Foo
   , Bar
   , Baz
+  , FooBarBaz
   , fooBarBazToText
   , fooBarBazRouter
   , genFooBarBaz
@@ -21,7 +22,9 @@ data Foo = Foo deriving (Show)
 data Bar = Bar deriving (Show)
 data Baz = Baz deriving (Show)
 
-fooBarBazToText :: Shrubbery.Union [Foo, Bar, Baz] -> Text
+type FooBarBaz = Shrubbery.Union [Foo, Bar, Baz]
+
+fooBarBazToText :: FooBarBaz -> Text
 fooBarBazToText =
   Shrubbery.dissect
   $ Shrubbery.branchBuild
@@ -30,15 +33,15 @@ fooBarBazToText =
   $ Shrubbery.branch (\Baz -> "baz")
   $ Shrubbery.branchEnd
 
-fooBarBazRouter :: Beeline.Router r => r(Shrubbery.Union [Foo, Bar, Baz])
+fooBarBazRouter :: Beeline.Router r => r FooBarBaz
 fooBarBazRouter =
   Beeline.routeList
-  $ Beeline.addRoute (Beeline.piece "foo" $ Beeline.end HTTP.GET Foo)
-  $ Beeline.addRoute (Beeline.piece "bar" $ Beeline.end HTTP.GET Bar)
-  $ Beeline.addRoute (Beeline.piece "baz" $ Beeline.end HTTP.GET Baz)
+  $ Beeline.addRoute (Beeline.route Foo $ Beeline.piece "foo" $ Beeline.end HTTP.GET)
+  $ Beeline.addRoute (Beeline.route Bar $ Beeline.piece "bar" $ Beeline.end HTTP.GET)
+  $ Beeline.addRoute (Beeline.route Baz $ Beeline.piece "baz" $ Beeline.end HTTP.GET)
   $ Beeline.emptyRoutes
 
-genFooBarBaz :: HH.Gen (Shrubbery.Union [Foo, Bar, Baz])
+genFooBarBaz :: HH.Gen FooBarBaz
 genFooBarBaz =
   Gen.element
     [ Shrubbery.unify Foo


### PR DESCRIPTION
This adds the ability to have multiple path parameters to Beeline router
definitions.

There are several available approaches for doing this. I opted to take
an approach that does not require an additional type parameter to be
specified at the router level. I.E., we can still write

```
appRouter :: Router r => r AppRoute
```

rather than needing to write

```
appRouter :: Router => r AppRoute AppRoute
```

Protecting this top-level context from the extra type parameter
unfortunately required adding a new inner context level where the fully
constructor route type to full values from during generate can vary from
the type's constructor function as the parameters are being specified.

The `end` and `subroute` functions begin construction of a route in this
next context and `route` finishes it when all the parameters of the
constructor function have been filled.

This ends up separating the HTTP method from the route data constructor,
but I think this is probably the most accurate representation of the
router as a tree, where the HTTP methods are the the leaves. The data
constructors for the route values are the trunks the of the branches,
and the route list structure is the joints between the branches.