### PR TITLE
Adds basic auth support to Request

### DIFF
--- a/beeline-http-client/beeline-http-client.cabal
+++ b/beeline-http-client/beeline-http-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           beeline-http-client
-version:        0.8.0.0
+version:        0.8.1.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-http#readme>
 homepage:       https://github.com/flipstone/beeline#readme
 bug-reports:    https://github.com/flipstone/beeline/issues

--- a/beeline-http-client/package.yaml
+++ b/beeline-http-client/package.yaml
@@ -1,5 +1,5 @@
 name:                beeline-http-client
-version:             0.8.0.0
+version:             0.8.1.0
 github:              "flipstone/beeline/beeline-http-client"
 license:             BSD3
 author:              "Author name here"

--- a/beeline-http-client/src/Beeline/HTTP/Client/HTTPRequest.hs
+++ b/beeline-http-client/src/Beeline/HTTP/Client/HTTPRequest.hs
@@ -8,6 +8,7 @@ module Beeline.HTTP.Client.HTTPRequest
   , StatusResult (ExpectedStatus, UnexpectedStatus)
   , Request (Request, baseURI, baseHTTPRequest, route, query, headers, additionalHeaders, body)
   , defaultRequest
+  , applyBasicAuth
   , buildHTTPRequest
   , handleHTTPResponse
   ) where
@@ -68,6 +69,16 @@ defaultRequest =
     , headers = NoHeaderParams
     , additionalHeaders = []
     , body = NoRequestBody
+    }
+
+applyBasicAuth ::
+  BS.ByteString ->
+  BS.ByteString ->
+  Request route query header body ->
+  Request route query header body
+applyBasicAuth user password req =
+  req
+    { baseHTTPRequest = HTTP.applyBasicAuth user password . baseHTTPRequest $ req
     }
 
 httpRequestThrow ::


### PR DESCRIPTION
This just adds a small function to let users add basic authentication
credentials to Beeline `Requests` by delegating to the corresponding
function in Network.HTTP.Client.
