### PR TITLE
Allow bytestring-0.12, text-2.1, use newer Shrubbery

### DIFF
--- a/beeline-http-client/beeline-http-client.cabal
+++ b/beeline-http-client/beeline-http-client.cabal
@@ -41,14 +41,14 @@ library
   build-depends:
       base >=4.7 && <5
     , beeline-routing ==0.2.*
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , case-insensitive ==1.2.*
     , containers ==0.6.*
     , dlist >=1.0 && <2.0
     , http-client ==0.7.*
     , http-types ==0.12.*
     , network-uri ==2.6.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors
@@ -67,12 +67,12 @@ test-suite beeline-http-client-test
       base >=4.7 && <5
     , beeline-http-client
     , beeline-routing ==0.2.*
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , hedgehog
     , http-client ==0.7.*
     , http-types ==0.12.*
     , random ==1.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , wai ==3.2.*
     , warp ==3.3.*
   default-language: Haskell2010

--- a/beeline-http-client/package.yaml
+++ b/beeline-http-client/package.yaml
@@ -18,10 +18,10 @@ description:         Please see the README on GitHub at <https://github.com/gith
 dependencies:
 - base >= 4.7 && < 5
 - beeline-routing >= 0.2 && < 0.3
-- bytestring >= 0.11 && < 0.12
+- bytestring >= 0.11 && < 0.13
 - http-client >= 0.7 && < 0.8
 - http-types >= 0.12 && < 0.13
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 
 flags:
   strict:

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,4 +17,4 @@ flags:
 
 extra-deps:
   - git: https://github.com/flipstone/shrubbery.git
-    commit: 73bea50a23ec60106eae9aa75a06ee854beb2e71
+    commit: 74bf67fb7e9e797c51380ed0fbafbd744caffb09

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,15 @@
 
 packages:
 - completed:
-    commit: 73bea50a23ec60106eae9aa75a06ee854beb2e71
+    commit: 74bf67fb7e9e797c51380ed0fbafbd744caffb09
     git: https://github.com/flipstone/shrubbery.git
     name: shrubbery
     pantry-tree:
-      sha256: e18a9032ca90d613943b023bdc2b362e42cfb1761c31886f83270e40a54d5095
-      size: 1737
-    version: 0.2.1.0
+      sha256: feb7f7b0064df90a1d7a9594769debd005d34a93b6011f70aa5b6d6381f406e6
+      size: 1739
+    version: 0.2.2.0
   original:
-    commit: 73bea50a23ec60106eae9aa75a06ee854beb2e71
+    commit: 74bf67fb7e9e797c51380ed0fbafbd744caffb09
     git: https://github.com/flipstone/shrubbery.git
 snapshots:
 - completed:


### PR DESCRIPTION
GHC 9.8 ships newer boot libraries. Since Beeline works fine on GHC 9.8, it would be nice to allow these library versions.
