### PR TITLE
Updates licensing

### DIFF
--- a/beeline-examples/LICENSE
+++ b/beeline-examples/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2025 Flipstone Technology Partners
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/beeline-examples/beeline-examples.cabal
+++ b/beeline-examples/beeline-examples.cabal
@@ -9,10 +9,11 @@ version:        0.2.1.1
 description:    Please see the README on GitHub at <https://github.com/githubuser/beeline-examples#readme>
 homepage:       https://github.com/flipstone/beeline#readme
 bug-reports:    https://github.com/flipstone/beeline/issues
-author:         Author name here
-maintainer:     example@example.com
-copyright:      2023 Author name here
-license:        BSD3
+author:         Flipstone Technology Partners
+maintainer:     development@flipstone.com
+copyright:      2025 Flipstone Technology Partners
+license:        MIT
+license-file:   LICENSE
 build-type:     Simple
 
 source-repository head

--- a/beeline-examples/package.yaml
+++ b/beeline-examples/package.yaml
@@ -1,10 +1,11 @@
-name:                beeline-examples
-version:             0.2.1.1
-github:              "flipstone/beeline/beeline-examples"
-license:             BSD3
-author:              "Author name here"
-maintainer:          "example@example.com"
-copyright:           "2023 Author name here"
+name: beeline-examples
+version: 0.2.1.1
+github: "flipstone/beeline/beeline-examples"
+author: Flipstone Technology Partners
+maintainer: development@flipstone.com
+copyright: 2025 Flipstone Technology Partners
+license: MIT
+license-file: LICENSE
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package

--- a/beeline-http-client/beeline-http-client.cabal
+++ b/beeline-http-client/beeline-http-client.cabal
@@ -9,10 +9,10 @@ version:        0.9.0.1
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-http#readme>
 homepage:       https://github.com/flipstone/beeline#readme
 bug-reports:    https://github.com/flipstone/beeline/issues
-author:         Author name here
-maintainer:     example@example.com
-copyright:      2023 Author name here
-license:        BSD3
+author:         Flipstone Technology Partners
+maintainer:     development@flipstone.com
+copyright:      2025 Flipstone Technology Partners
+license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:

--- a/beeline-http-client/package.yaml
+++ b/beeline-http-client/package.yaml
@@ -1,10 +1,11 @@
-name:                beeline-http-client
-version:             0.9.0.1
-github:              "flipstone/beeline/beeline-http-client"
-license:             BSD3
-author:              "Author name here"
-maintainer:          "example@example.com"
-copyright:           "2023 Author name here"
+name: beeline-http-client
+version: 0.9.0.1
+github: "flipstone/beeline/beeline-http-client"
+author: Flipstone Technology Partners
+maintainer: development@flipstone.com
+copyright: 2025 Flipstone Technology Partners
+license: MIT
+license-file: LICENSE
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package

--- a/beeline-params/beeline-params.cabal
+++ b/beeline-params/beeline-params.cabal
@@ -11,6 +11,7 @@ homepage:       https://github.com/flipstone/beeline#readme
 bug-reports:    https://github.com/flipstone/beeline/issues
 author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
+copyright:      2025 Flipstone Technology Partners
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/beeline-params/package.yaml
+++ b/beeline-params/package.yaml
@@ -1,10 +1,11 @@
 name: beeline-params
 version: 0.1.0.1
-license: MIT
-author: "Flipstone Technology Partners"
-maintainer: "development@flipstone.com"
 github: "flipstone/beeline/beeline-params"
-
+author: Flipstone Technology Partners
+maintainer: development@flipstone.com
+copyright: 2025 Flipstone Technology Partners
+license: MIT
+license-file: LICENSE
 
 description:         Please see the README on GitHub at <https://github.com/flipstone/beeline#readme>
 tested-with:

--- a/beeline-routing/beeline-routing.cabal
+++ b/beeline-routing/beeline-routing.cabal
@@ -11,6 +11,7 @@ homepage:       https://github.com/flipstone/beeline#readme
 bug-reports:    https://github.com/flipstone/beeline/issues
 author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
+copyright:      2025 Flipstone Technology Partners
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/beeline-routing/package.yaml
+++ b/beeline-routing/package.yaml
@@ -1,10 +1,11 @@
 name: beeline-routing
 version: 0.3.0.2
-license: MIT
-author: "Flipstone Technology Partners"
-maintainer: "development@flipstone.com"
 github: "flipstone/beeline/beeline-routing"
-
+license: MIT
+license-file: LICENSE
+author: Flipstone Technology Partners
+maintainer: development@flipstone.com
+copyright: 2025 Flipstone Technology Partners
 
 description:         Please see the README on GitHub at <https://github.com/flipstone/beeline#readme>
 tested-with:


### PR DESCRIPTION
Added missing LICENSE file for beeline-examples, corrected license fields in cabal files to MIT, and added copyright fields.