### PR TITLE
Update haskell-tools and enable Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # The haskell-tools dev image pinned in compose.yaml. It is pinned to a
+  # release tag plus digest, which is what makes it visible to Dependabot at
+  # all; a per-commit sha tag is not comparable. Bumps stay within the pinned
+  # GHC version: the GHC version sits in the part of the tag Dependabot treats
+  # as an opaque prefix, so a GHC upgrade stays a deliberate manual re-pin
+  # alongside the resolver changes it requires.
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # One PR for all action bumps rather than one PR per action.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   dev:
-    image: ghcr.io/flipstone/haskell-tools:debian-ghc-9.10.3-42503e5
+    image: ghcr.io/flipstone/haskell-tools:debian-ghc-9.10.3-build-2026.8.7.56@sha256:ba140d293971c86a850b2d20e1636c72554fc7163b4aea7c26c5d0be87c64b96
     volumes:
       - .:${PROJECT_DIR}
       - flipstone_stack_root:/stack-root


### PR DESCRIPTION
Re-pin the haskell-tools dev image from a per-commit sha tag to the current
release tag plus digest, and add a Dependabot config so future releases arrive
as bump PRs instead of going unnoticed.

haskell-tools mints release tags (debian-ghc-X.Y.Z-build-YYYY.M.D.N) from main
builds that change the image precisely so downstream repos can pin them and be
bumped; a sha tag is not comparable, so Dependabot could see nothing before
this. Bumps stay within the pinned GHC version, since the GHC version sits in
the part of the tag Dependabot treats as an opaque prefix.

Verified: the new image carries an identical toolchain to the old pin --
ghc 9.10.3, stack 3.11.1, cabal 3.14.2.0, hls 2.12.0.0, fourmolu 0.19.0.1,
hlint v3.10 -- so nothing here should reformat or rebuild differently. The
change it does carry is size: 4.61 GB against 6.15 GB.
Coverage: the tracked image is exercised, not merely pulled — `main.yaml` runs
the build, formatting, cabal-check and shellcheck jobs via
`docker compose run --rm dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)